### PR TITLE
Fix/width of top

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,7 +69,7 @@
     <main class="container-fluid p-0">
       <section class="d-flex align-items-center vh-100">
         <div class="m-auto">
-          <h1 class="display-1">Portfolio</h1>
+          <h1>Portfolio</h1>
           <h2>IT engineer</h2>
         </div>
       </section>

--- a/index.html
+++ b/index.html
@@ -19,6 +19,7 @@
       referrerpolicy="no-referrer"
     />
     <link rel="stylesheet" href="css/main.css" />
+    <link rel="stylesheet" href="css/top.css" />
     <link rel="stylesheet" href="css/work.css" />
     <link rel="stylesheet" href="css/skill.css" />
     <link rel="stylesheet" href="css/experience.css" />

--- a/index.html
+++ b/index.html
@@ -19,7 +19,6 @@
       referrerpolicy="no-referrer"
     />
     <link rel="stylesheet" href="css/main.css" />
-    <link rel="stylesheet" href="css/top.css" />
     <link rel="stylesheet" href="css/work.css" />
     <link rel="stylesheet" href="css/skill.css" />
     <link rel="stylesheet" href="css/experience.css" />


### PR DESCRIPTION
見出しの「Portfolio」が幅の小さいスマホで見た場合に、画面幅をはみ出してしまうバグの修正